### PR TITLE
[Feat] 즐겨찾기 UI 추가 및 즐겨찾기에 따른 정렬 기능 구현

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -14,6 +14,7 @@ interface Note {
   content: string;
   createdAt: string;
   updatedAt: string;
+  isStar: boolean; // 즐겨찾기 여부 추가
 }
 
 const Main = ({ isDarkMode, toggleTheme }: MainProps) => {
@@ -36,17 +37,21 @@ const Main = ({ isDarkMode, toggleTheme }: MainProps) => {
     const sortNotes = () => {
       if (noteList.length > 0) {
         const sorted = [...noteList];
-        if (sortOption === "recentlyCreated") {
-          sorted.sort(
-            (a, b) =>
+        sorted.sort((a, b) => {
+          if (a.isStar !== b.isStar) {
+            return b.isStar ? 1 : -1;
+          }
+          if (sortOption === "recentlyCreated") {
+            return (
               new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-          );
-        } else if (sortOption === "recentlyModified") {
-          sorted.sort(
-            (a, b) =>
+            );
+          } else if (sortOption === "recentlyModified") {
+            return (
               new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-          );
-        }
+            );
+          }
+          return 0;
+        });
         setSortedNotes(sorted);
       }
     };
@@ -60,6 +65,14 @@ const Main = ({ isDarkMode, toggleTheme }: MainProps) => {
 
   const handleSortChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setSortOption(event.target.value);
+  };
+
+  const toggleStar = (id: string) => {
+    const updatedNotes = noteList.map((note) =>
+      note.id === id ? { ...note, isStar: !note.isStar } : note
+    );
+    setNoteList(updatedNotes);
+    localStorage.setItem("noteList", JSON.stringify(updatedNotes));
   };
 
   return (
@@ -91,6 +104,8 @@ const Main = ({ isDarkMode, toggleTheme }: MainProps) => {
                 title={note.title}
                 content={note.content}
                 updatedAt={note.updatedAt}
+                isStar={note.isStar}
+                toggleStar={toggleStar}
               />
             ))
           ) : (

--- a/src/components/NoteItem.tsx
+++ b/src/components/NoteItem.tsx
@@ -6,21 +6,29 @@ interface NoteItemProps {
   title: string;
   content: string;
   updatedAt: string;
+  isStar: boolean;
+  toggleStar: (id: string) => void;
 }
 
 const NoteItem = (props: NoteItemProps) => {
-  const { id, title, content, updatedAt } = props;
+  const { id, title, content, updatedAt, isStar, toggleStar } = props;
   const navigate = useNavigate();
 
   const handleEdit = () => {
     navigate(`/note/${id}`);
   };
 
+  const handleToggleStar = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    toggleStar(id);
+  };
+
   return (
     <NoteItemContainer onClick={handleEdit}>
       <NoteItemText>{title}</NoteItemText>
       <NoteDescription>{content}</NoteDescription>
-      <NoteUpdated>{new Date(updatedAt).toLocaleString()}</NoteUpdated>
+      <NoteTime>{new Date(updatedAt).toLocaleString()}</NoteTime>
+      <StarButton onClick={handleToggleStar} isStar={isStar} />
     </NoteItemContainer>
   );
 };
@@ -34,6 +42,7 @@ const NoteItemContainer = styled.div`
   border-radius: 0.8rem;
   box-shadow: 0 0.2rem 0.4rem rgba(0, 0, 0, 0.1);
   cursor: pointer;
+  position: relative;
 
   ${({ theme }) =>
     theme.isDarkMode &&
@@ -62,8 +71,20 @@ const NoteDescription = styled.p`
   `}
 `;
 
-const NoteUpdated = styled.p`
-  font-size: 1rem;
+const NoteTime = styled.p`
+  font-size: 0.8rem;
   color: ${({ theme }) => theme.colors.lightgray};
   margin-top: 0.4rem;
+`;
+
+const StarButton = styled.button<{ isStar: boolean }>`
+  background: ${({ isStar, theme }) => (isStar ? theme.colors.blue : "none")};
+  border: 0.15rem solid ${({ theme }) => theme.colors.blue};
+  cursor: pointer;
+  width: 2rem;
+  height: 3rem;
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  border-radius: 0.5rem;
 `;


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #17 

<!-- ex) #이슈번호, #이슈번호 -->

## 📝작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 즐겨찾기 버튼 추가
- 즐겨찾기 추가 시 해당 노트아이템은 가장 위에 정렬되도록 구현
- 즐겨찾기 노트가 여러 개라면 추가된 순으로 정렬

### 스크린샷 (선택)
<img width="391" alt="스크린샷 2024-06-12 13 06 44" src="https://github.com/Kjiw0n/react-note-app/assets/128016888/0e728565-cf23-407c-883b-82f53b74271a">

<img width="391" alt="스크린샷 2024-06-12 13 06 49" src="https://github.com/Kjiw0n/react-note-app/assets/128016888/e78a6a38-3f9c-49d2-b791-a77e014edfdb">
